### PR TITLE
Explicitly reference the loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,15 +15,15 @@ module.exports = {
       { test: /\.(png|jpg)$/, loader: 'url-loader?limit=8192'},
       // helps to load bootstrap's css.
       { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&minetype=application/font-woff' },
+        loader: 'url-loader?limit=10000&minetype=application/font-woff' },
       { test: /\.woff2$/,
-        loader: 'url?limit=10000&minetype=application/font-woff' },
+        loader: 'url-loader?limit=10000&minetype=application/font-woff' },
       { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&minetype=application/octet-stream' },
+        loader: 'url-loader?limit=10000&minetype=application/octet-stream' },
       { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'file' },
+        loader: 'file-loader' },
       { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-        loader: 'url?limit=10000&minetype=image/svg+xml' }
+        loader: 'url-loader?limit=10000&minetype=image/svg+xml' }
     ]
   },
   devtool: 'source-map'


### PR DESCRIPTION
By using the short name for a loader, another node module that matches the loader shortname might be used, giving weird errors. This is prevented by referencing the loader by its full name (by adding '-loader' to most short names).

This prevents errors like these: 
```
/vagrant/node_modules/loader-runner/lib/loadLoader.js:35
                        throw new Error("Module '" + loader.path + "' is not a loader (must have normal or pitch function)");
                        ^

Error: Module '/vagrant/node_modules/url/url.js' is not a loader (must have normal or pitch function)
    at loadLoader (/vagrant/node_modules/loader-runner/lib/loadLoader.js:35:10)
    at iteratePitchingLoaders (/vagrant/node_modules/loader-runner/lib/LoaderRunner.js:169:2)
    at runLoaders (/vagrant/node_modules/loader-runner/lib/LoaderRunner.js:362:2)
    at NormalModule.doBuild (/vagrant/node_modules/webpack/lib/NormalModule.js:179:3)
    at NormalModule.build (/vagrant/node_modules/webpack/lib/NormalModule.js:268:15)
    at Compilation.buildModule (/vagrant/node_modules/webpack/lib/Compilation.js:142:10)
    at factoryCallback (/vagrant/node_modules/webpack/lib/Compilation.js:325:11)
    at factory (/vagrant/node_modules/webpack/lib/NormalModuleFactory.js:253:5)
    at applyPluginsAsyncWaterfall (/vagrant/node_modules/webpack/lib/NormalModuleFactory.js:99:14)
    at /vagrant/node_modules/tapable/lib/Tapable.js:204:11
```